### PR TITLE
Extend ransack search with module

### DIFF
--- a/lib/mobility/plugins/ransack.rb
+++ b/lib/mobility/plugins/ransack.rb
@@ -17,11 +17,11 @@ module Mobility
         end
       end
 
-      def ransack(params = {}, options = {})
-        Search.new(self, params, options)
+      def ransack(*)
+        super.extend(Search)
       end
 
-      class Search < ::Ransack::Search
+      module Search
         def result(opts = {})
           sorted = sorts.inject(super) do |relation, sort|
             predicate = ::Ransack::Visitor.new.visit_Ransack_Nodes_Sort(sort)


### PR DESCRIPTION
This is a less intrusive way to intercept the ransack result in order to apply Mobility scope(s). Since we now do `super.extend(Search)`, any other gem that (god forbid) *also* overrides the `ransack` method will still have its code run, whereas the current code would completely override that code.