### PR TITLE
Enable Mobility 1.x compatibility

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,57 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    continue-on-error: ${{ matrix.experimental }}
+    name: ${{ matrix.feature }} ruby-${{ matrix.ruby }} ${{ matrix.orm.name }}-${{ matrix.orm.version}} ${{ matrix.database }}
+    strategy:
+      fail-fast: false
+      matrix:
+        ruby:
+          - '2.7'
+          - '2.6'
+          - '2.5'
+        rails:
+          - '5.2'
+          - '6.0'
+    env:
+      BUNDLE_JOBS: 4
+      BUNDLE_PATH: vendor/bundle
+      MYSQL_PASSWORD: root
+      PGHOST: localhost
+      PGPORT: 5432
+      PGUSER: postgres
+      RAILS_VERSION: ${{ matrix.rails }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Update packages
+        run: sudo apt-get update
+      - name: Install Sqlite
+        run: sudo apt-get install libsqlite3-dev -y
+        if: matrix.database == 'sqlite3'
+      - id: cache-bundler
+        uses: actions/cache@v1
+        with:
+          path: vendor/bundle
+          key: ${{ matrix.ruby }}-${{ matrix.rails.name }}-${{ hashFiles('mobility.gemspec') }}-${{ hashFiles('Gemfile') }}
+      - name: Setup Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ${{ matrix.ruby }}
+      - name: Install latest Bundler
+        run: gem install bundler --no-document
+      - name: Install dependencies
+        run: bundle install
+      - name: Run tests
+        run: bundle exec rake

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,0 @@
-sudo: false
-language: ruby
-rvm:
-  - 2.4.3
-  - 2.5.1
-before_install: gem install bundler -v 1.16.0
-env:
-  - RAILS_VERSION=5.1
-  - RAILS_VERSION=5.2

--- a/lib/mobility/plugins/ransack.rb
+++ b/lib/mobility/plugins/ransack.rb
@@ -4,6 +4,8 @@ require "mobility"
 module Mobility
   module Plugins
     module Ransack
+      extend Plugin
+
       # Applies ransack plugin.
       # @param [Attributes] attributes
       # @param [Boolean] option
@@ -41,5 +43,7 @@ module Mobility
         end
       end
     end
+
+    register_plugin(:ransack, Ransack)
   end
 end

--- a/lib/mobility/ransack/version.rb
+++ b/lib/mobility/ransack/version.rb
@@ -1,5 +1,5 @@
 module Mobility
   module Ransack
-    VERSION = "0.2.2"
+    VERSION = "1.0.0.alpha"
   end
 end

--- a/mobility-ransack.gemspec
+++ b/mobility-ransack.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency 'ransack', '>= 1.8.0', '< 3.0'
-  spec.add_dependency 'mobility', '~> 0.8.0'
+  spec.add_dependency 'mobility', '>= 0.8.0'
   spec.add_development_dependency "rake", ">= 12.3.3"
   spec.add_development_dependency 'rspec', '~> 3.0'
   spec.add_development_dependency 'sqlite3', '~> 1.3', '>= 1.3.0'

--- a/mobility-ransack.gemspec
+++ b/mobility-ransack.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency 'ransack', '>= 1.8.0', '< 3.0'
-  spec.add_dependency 'mobility', '>= 0.8.0'
+  spec.add_dependency 'mobility', '~> 1.0.0.beta1'
   spec.add_development_dependency "rake", ">= 12.3.3"
   spec.add_development_dependency 'rspec', '~> 3.0'
   spec.add_development_dependency 'sqlite3', '~> 1.3', '>= 1.3.0'

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -37,9 +37,12 @@ RSpec.configure do |config|
 end
 
 Mobility.configure do |config|
-  config.plugins += [:ransack]
-  config.default_backend = :key_value
-  config.default_options[:ransack] = true
+  config.plugins do
+    ransack
+    backend :key_value
+    reader
+    writer
+  end
 end
 
 class MobilityRansackTest < ActiveRecord::Migration[ENV['RAILS_VERSION'].to_f]


### PR DESCRIPTION
Relaxes mobility version constraint to allow compatibility with new 1.0.0.beta1 `mobility` library.

For now I'm just using this for testing, I'm not sure if further updates need to be made to this library to be fully compatible with `mobility` 1.x.