### PR TITLE
Update mobility-ransack.gemspec

### DIFF
--- a/mobility-ransack.gemspec
+++ b/mobility-ransack.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |spec|
   spec.files        = Dir['{lib/**/*,[A-Z]*}']
   spec.require_paths = ["lib"]
 
-  spec.add_dependency 'ransack',  '>= 1.8.0', '< 3.0'
+  spec.add_dependency 'ransack',  '>= 1.8.0', '< 3.1'
   spec.add_dependency 'mobility', '>= 1.0.1', '< 2.0'
   spec.add_development_dependency "rake", ">= 12.3.3"
   spec.add_development_dependency 'rspec', '~> 3.0'

--- a/mobility-ransack.gemspec
+++ b/mobility-ransack.gemspec
@@ -13,13 +13,13 @@ Gem::Specification.new do |spec|
   spec.homepage      = "https://github.com/shioyama/mobility-ransack"
   spec.license       = "MIT"
 
-  spec.files        = Dir['{lib/**/*,[A-Z]*}']
+  spec.files         = Dir["{lib/**/*,[A-Z]*}"]
   spec.require_paths = ["lib"]
 
-  spec.add_dependency 'ransack',  '>= 1.8.0', '< 3.1'
-  spec.add_dependency 'mobility', '>= 1.0.1', '< 2.0'
+  spec.add_dependency "ransack",  ">= 1.8.0", "< 3.2"
+  spec.add_dependency "mobility", ">= 1.0.1", "< 2.0"
   spec.add_development_dependency "rake", ">= 12.3.3"
-  spec.add_development_dependency 'rspec', '~> 3.0'
-  spec.add_development_dependency 'sqlite3', '~> 1.3', '>= 1.3.0'
-  spec.add_development_dependency "database_cleaner", '~> 1.7', '>= 1.7.0'
+  spec.add_development_dependency "rspec", "~> 3.0"
+  spec.add_development_dependency "sqlite3", "~> 1.3", ">= 1.3.0"
+  spec.add_development_dependency "database_cleaner", "~> 1.7", ">= 1.7.0"
 end


### PR DESCRIPTION
Hi! as far as I can look at ransack's changelog, there's no problem about upgrading ransack dependency version.