### PR TITLE
Allow Ransack 3.2

### DIFF
--- a/mobility-ransack.gemspec
+++ b/mobility-ransack.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |spec|
   spec.files         = Dir["{lib/**/*,[A-Z]*}"]
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "ransack",  ">= 1.8.0", "< 3.2"
+  spec.add_dependency "ransack",  ">= 1.8.0", "< 3.3"
   spec.add_dependency "mobility", ">= 1.0.1", "< 2.0"
   spec.add_development_dependency "rake", ">= 12.3.3"
   spec.add_development_dependency "rspec", "~> 3.0"


### PR DESCRIPTION
Recently Ransack released version 3.2.0 

As per changelog, there should not be breaking changes: 

https://github.com/activerecord-hackery/ransack/blob/main/CHANGELOG.md#320---2022-05-08

It is not clear to me whether if Ransack follows SemVer, so I'm keeping using minor version lock

Specs are green on my development machine, please let me know if anything else is needed