### PR TITLE
Add 'require "mobility/ransack"' into plugin file

### DIFF
--- a/lib/mobility/plugins/ransack.rb
+++ b/lib/mobility/plugins/ransack.rb
@@ -1,5 +1,6 @@
 require "ransack"
 require "mobility"
+require "mobility/ransack"
 
 module Mobility
   module Plugins
@@ -21,7 +22,6 @@ module Mobility
         end
       end
     end
-
     register_plugin(:ransack, Ransack)
   end
 end


### PR DESCRIPTION
This PR is related to issue https://github.com/shioyama/mobility-ransack/issues/25

This might be connected to Rails 7 autoloading changes