### PR TITLE
Allow Ransack 3.x

### DIFF
--- a/mobility-ransack.gemspec
+++ b/mobility-ransack.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |spec|
   spec.files         = Dir["{lib/**/*,[A-Z]*}"]
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "ransack",  ">= 1.8.0", "< 3.3"
+  spec.add_dependency "ransack",  ">= 1.8.0", "< 4"
   spec.add_dependency "mobility", ">= 1.0.1", "< 2.0"
   spec.add_development_dependency "rake", ">= 12.3.3"
   spec.add_development_dependency "rspec", "~> 3.0"


### PR DESCRIPTION
Ransack is supposed to follow SemVer, so it is possible to set the upper limit to `< 4`

Ref: activerecord-hackery/ransack#1381