### PR TITLE
Add Ransack 4 compatibility

### DIFF
--- a/mobility-ransack.gemspec
+++ b/mobility-ransack.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |spec|
   spec.files         = Dir["{lib/**/*,[A-Z]*}"]
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "ransack",  ">= 1.8.0", "< 3.3"
+  spec.add_dependency "ransack",  ">= 1.8.0", "< 5.0"
   spec.add_dependency "mobility", ">= 1.0.1", "< 2.0"
   spec.add_development_dependency "rake", ">= 12.3.3"
   spec.add_development_dependency "rspec", "~> 3.0"

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -88,6 +88,14 @@ class Author < ActiveRecord::Base
   extend Mobility
   has_many :posts
   translates :website, type: :string
+
+  def self.ransackable_attributes(auth_object = nil)
+    %w[website]
+  end
+
+  def self.ransackable_associations(auth_object = nil)
+    %w[mobility_string_translations posts]
+  end
 end
 
 class Post < ActiveRecord::Base
@@ -95,8 +103,24 @@ class Post < ActiveRecord::Base
   translates :title, type: :string
   translates :content, type: :text
   belongs_to :author, optional: true
+
+  def self.ransackable_attributes(auth_object = nil)
+    %w[title content tags]
+  end
+
+  def self.ransackable_associations(auth_object = nil)
+    %w[mobility_string_translations mobility_text_translations author]
+  end
 end
 
 class Comment < ActiveRecord::Base
   belongs_to :post
+
+  def self.ransackable_attributes(auth_object = nil)
+    []
+  end
+
+  def self.ransackable_associations(auth_object = nil)
+    %w[post]
+  end
 end


### PR DESCRIPTION
Check if this works with column backend

Locked by:
- #27
- #29
- #30
- #28 (release a version compatible with Ransack 3.x as a foundation for this PR)

Close shioyama/mobility-ransack#31

TODO:
- [ ] Add an entry in the changelog
- [ ] Bump minor version